### PR TITLE
Fix proxy tests

### DIFF
--- a/src/main/java/com/jfrog/xray/client/impl/XrayClient.java
+++ b/src/main/java/com/jfrog/xray/client/impl/XrayClient.java
@@ -22,7 +22,7 @@ public class XrayClient {
      * Username, API key, and custom url
      */
     public static Xray create(String url, String username, String password, String userAgent, boolean trustSelfSignCert, ProxyConfig proxyConfig) {
-         HttpBuilderBase configurator = new HttpBuilderBase() {
+        HttpBuilderBase configurator = new HttpBuilderBase() {
         };
         configurator.hostFromUrl(url)
                 .authentication(username, password, true)

--- a/src/main/java/com/jfrog/xray/client/impl/XrayClient.java
+++ b/src/main/java/com/jfrog/xray/client/impl/XrayClient.java
@@ -21,8 +21,8 @@ public class XrayClient {
     /**
      * Username, API key, and custom url
      */
-    public static Xray create(String url, String username, String password, String userAgent, ProxyConfig proxyConfig) {
-        HttpBuilderBase configurator = new HttpBuilderBase() {
+    public static Xray create(String url, String username, String password, String userAgent, boolean trustSelfSignCert, ProxyConfig proxyConfig) {
+         HttpBuilderBase configurator = new HttpBuilderBase() {
         };
         configurator.hostFromUrl(url)
                 .authentication(username, password, true)
@@ -30,12 +30,13 @@ public class XrayClient {
                 .socketTimeout(CONNECTION_TIMEOUT_MILLISECONDS)
                 .userAgent(userAgent)
                 .proxy(proxyConfig)
+                .trustSelfSignCert(trustSelfSignCert)
                 .addRequestInterceptor(new PreemptiveAuthInterceptor());
 
         return new XrayImpl(configurator.build(), url);
     }
 
-    public static Xray create(String url, String username, String password, ProxyConfig proxyConfig) {
-        return create(url, username, password, DEFAULT_USER_AGENT, proxyConfig);
+    public static Xray create(String url, String username, String password, boolean trustSelfSignCert, ProxyConfig proxyConfig) {
+        return create(url, username, password, DEFAULT_USER_AGENT, trustSelfSignCert, proxyConfig);
     }
 }

--- a/src/test/java/com/jfrog/xray/client/impl/test/SummaryTests.java
+++ b/src/test/java/com/jfrog/xray/client/impl/test/SummaryTests.java
@@ -45,11 +45,11 @@ public class SummaryTests extends XrayTestsBase {
 
         // Assert that request passed through proxy
         String requestBody = ((String) expectations[0].getHttpRequest().getBody().getValue());
-        assertTrue(StringUtils.contains(requestBody, "acegi-security"));
+        assertTrue(StringUtils.contains(requestBody, "spring-security-oauth2"));
 
         // Assert that response passed through proxy
         String responseBody = ((String) expectations[0].getHttpResponse().getBody().getValue());
-        assertTrue(StringUtils.contains(responseBody, "acegi-security"));
+        assertTrue(StringUtils.contains(responseBody, "spring-security-oauth2"));
     }
 
     private void testArtifactSummaryComponent(Xray xray) throws IOException {
@@ -66,9 +66,9 @@ public class SummaryTests extends XrayTestsBase {
             assertNotNull(artifact.getGeneral());
             assertNotNull(artifact.getLicenses());
             assertNotNull(artifact.getIssues());
-            assertEquals(3, artifact.getIssues().size());
+            assertEquals(artifact.getIssues().size(), 4);
             assertNotNull(artifact.getIssues().get(0).getVulnerableComponents());
-            assertEquals(1, artifact.getIssues().get(0).getVulnerableComponents().size());
+            assertEquals(artifact.getIssues().get(0).getVulnerableComponents().size(), 1);
             assertEquals(artifact.getIssues().get(0).getVulnerableComponents().get(0).getFixedVersions().size(), 4);
         }
     }

--- a/src/test/java/com/jfrog/xray/client/impl/test/XrayTestsBase.java
+++ b/src/test/java/com/jfrog/xray/client/impl/test/XrayTestsBase.java
@@ -41,13 +41,13 @@ public class XrayTestsBase {
         String password = readParam(props, "password");
 
         // Create an xray client
-        xray = create(url, username, password, null);
+        xray = create(url, username, password, false, null);
 
         // Create an xray client that uses proxy
         ProxyConfig proxyConfig = new ProxyConfig();
         proxyConfig.setPort(8888);
         proxyConfig.setHost("localhost");
-        xrayProxies = create(url, username, password, proxyConfig);
+        xrayProxies = create(url, username, password, true, proxyConfig);
 
         // Create a mock proxy server
         mockServer = ClientAndServer.startClientAndServer(8888);


### PR DESCRIPTION
Fix proxy tests so that it can use the Netty's mockserver with https protocol. The fix allows mockserver to use self signed certificates.