### PR TITLE
Fix integration tests on Windows

### DIFF
--- a/src/test/java/com/jfrog/xray/client/impl/test/XrayTestsBase.java
+++ b/src/test/java/com/jfrog/xray/client/impl/test/XrayTestsBase.java
@@ -107,5 +107,8 @@ public class XrayTestsBase {
         xray.close();
         xrayProxies.close();
         mockServer.stop();
+        while (!mockServer.hasStopped()) {
+            System.out.println("Stopping mockServer...");
+        }
     }
 }


### PR DESCRIPTION
Fix the [following](https://ci.appveyor.com/project/jfrog-ecosystem/xray-client-java/build/job/g06nowvm8r5uw8ll#L65) error in test:
> Gradle suite > Gradle test > com.jfrog.xray.client.impl.test.SummaryTests > beforeMethod FAILED
    org.mockserver.client.SocketConnectionException: Unable to connect to socket /127.0.0.1:8888
        Caused by:
        io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: no further information: /127.0.0.1:8888
            Caused by:
            java.net.ConnectException: Connection refused: no further information

The root cause is an attempt to call `mockServer.reset()` before the mock server of the previous test had been stopped.

