### PR TITLE
Support more fields to the scan/graph response

### DIFF
--- a/src/main/java/com/jfrog/xray/client/impl/services/scan/ExtendedInformationImpl.java
+++ b/src/main/java/com/jfrog/xray/client/impl/services/scan/ExtendedInformationImpl.java
@@ -1,0 +1,46 @@
+package com.jfrog.xray.client.impl.services.scan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jfrog.xray.client.services.scan.ExtendedInformation;
+import com.jfrog.xray.client.services.scan.SeverityReasons;
+
+/**
+ * @author yahavi
+ **/
+public class ExtendedInformationImpl implements ExtendedInformation {
+    public SeverityReasonsImpl[] jfrogResearchSeverityReasons;
+    public String jfrogResearchSeverity;
+    public String shortDescription;
+    public String fullDescription;
+    public String remediation;
+
+    @Override
+    @JsonProperty("short_description")
+    public String getShortDescription() {
+        return shortDescription;
+    }
+
+    @Override
+    @JsonProperty("full_description")
+    public String getFullDescription() {
+        return fullDescription;
+    }
+
+    @Override
+    @JsonProperty("remediation")
+    public String getRemediation() {
+        return remediation;
+    }
+
+    @Override
+    @JsonProperty("jfrog_research_severity")
+    public String getJFrogResearchSeverity() {
+        return jfrogResearchSeverity;
+    }
+
+    @Override
+    @JsonProperty("jfrog_research_severity_reasons")
+    public SeverityReasons[] getJFrogResearchSeverityReasons() {
+        return jfrogResearchSeverityReasons;
+    }
+}

--- a/src/main/java/com/jfrog/xray/client/impl/services/scan/SeverityReasonsImpl.java
+++ b/src/main/java/com/jfrog/xray/client/impl/services/scan/SeverityReasonsImpl.java
@@ -1,0 +1,31 @@
+package com.jfrog.xray.client.impl.services.scan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jfrog.xray.client.services.scan.SeverityReasons;
+
+/**
+ * @author yahavi
+ **/
+public class SeverityReasonsImpl implements SeverityReasons {
+    public String description;
+    public boolean positive;
+    public String name;
+
+    @Override
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    @JsonProperty("is_positive")
+    public boolean isPositive() {
+        return positive;
+    }
+}

--- a/src/main/java/com/jfrog/xray/client/impl/services/scan/ViolationImpl.java
+++ b/src/main/java/com/jfrog/xray/client/impl/services/scan/ViolationImpl.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.xray.client.impl.services.common.CveImpl;
 import com.jfrog.xray.client.services.common.Cve;
 import com.jfrog.xray.client.services.scan.Component;
+import com.jfrog.xray.client.services.scan.ExtendedInformation;
 import com.jfrog.xray.client.services.scan.Violation;
 
 import java.util.List;
 import java.util.Map;
 
 public class ViolationImpl implements Violation {
+    private String updated;
     private String summary;
     private String severity;
     private String issueId;
@@ -19,6 +21,14 @@ public class ViolationImpl implements Violation {
     private List<CveImpl> cves;
     private List<String> references;
     private String ignoreRuleUrl;
+    private String watchName;
+    private ExtendedInformationImpl extendedInformation;
+
+    @Override
+    @JsonProperty("updated")
+    public String getUpdated() {
+        return updated;
+    }
 
     @Override
     @JsonProperty("cves")
@@ -72,5 +82,17 @@ public class ViolationImpl implements Violation {
     @JsonProperty("license_name")
     public String getLicenseName() {
         return licenseName;
+    }
+
+    @Override
+    @JsonProperty("watch_name")
+    public String getWatchName() {
+        return watchName;
+    }
+
+    @Override
+    @JsonProperty("extended_information")
+    public ExtendedInformation getExtendedInformation() {
+        return extendedInformation;
     }
 }

--- a/src/main/java/com/jfrog/xray/client/impl/services/scan/VulnerabilityImpl.java
+++ b/src/main/java/com/jfrog/xray/client/impl/services/scan/VulnerabilityImpl.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class VulnerabilityImpl implements Vulnerability {
 
+    private String edited;
     private String issueId;
     private String summary;
     private String severity;
@@ -18,6 +19,11 @@ public class VulnerabilityImpl implements Vulnerability {
     private List<CveImpl> cves;
     private List<String> references;
     private String ignoreRuleUrl;
+
+    @JsonProperty("edited")
+    public String getEdited() {
+        return edited;
+    }
 
     @Override
     @JsonProperty("issue_id")

--- a/src/main/java/com/jfrog/xray/client/services/scan/ExtendedInformation.java
+++ b/src/main/java/com/jfrog/xray/client/services/scan/ExtendedInformation.java
@@ -1,0 +1,23 @@
+package com.jfrog.xray.client.services.scan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author yahavi
+ **/
+public interface ExtendedInformation {
+    @JsonProperty("short_description")
+    String getShortDescription();
+
+    @JsonProperty("full_description")
+    String getFullDescription();
+
+    @JsonProperty("remediation")
+    String getRemediation();
+
+    @JsonProperty("jfrog_research_severity")
+    String getJFrogResearchSeverity();
+
+    @JsonProperty("jfrog_research_severity_reasons")
+    SeverityReasons[] getJFrogResearchSeverityReasons();
+}

--- a/src/main/java/com/jfrog/xray/client/services/scan/SeverityReasons.java
+++ b/src/main/java/com/jfrog/xray/client/services/scan/SeverityReasons.java
@@ -1,0 +1,18 @@
+package com.jfrog.xray.client.services.scan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author yahavi
+ **/
+public interface SeverityReasons {
+
+    @JsonProperty("name")
+    String getName();
+
+    @JsonProperty("description")
+    String getDescription();
+
+    @JsonProperty("is_positive")
+    boolean isPositive();
+}

--- a/src/main/java/com/jfrog/xray/client/services/scan/Violation.java
+++ b/src/main/java/com/jfrog/xray/client/services/scan/Violation.java
@@ -1,4 +1,20 @@
 package com.jfrog.xray.client.services.scan;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public interface Violation extends Vulnerability, License {
+    @JsonProperty("updated")
+    String getUpdated();
+
+    @Override
+    default String getEdited() {
+        // Edited field is available only in vulnerabilities. It is perfectly equal to the "updated" field.
+        return getUpdated();
+    }
+
+    @JsonProperty("watch_name")
+    String getWatchName();
+
+    @JsonProperty("extended_information")
+    ExtendedInformation getExtendedInformation();
 }

--- a/src/main/java/com/jfrog/xray/client/services/scan/Vulnerability.java
+++ b/src/main/java/com/jfrog/xray/client/services/scan/Vulnerability.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 public interface Vulnerability {
+    @JsonProperty("edited")
+    String getEdited();
 
     @JsonProperty("issue_id")
     String getIssueId();

--- a/src/test/resources/scan/graph/response-with-research.json
+++ b/src/test/resources/scan/graph/response-with-research.json
@@ -1,0 +1,95 @@
+{
+  "component_id": "artifactory",
+  "package_type": "Generic",
+  "violations": [
+    {
+      "issue_id": "XRAY-129823",
+      "references": [
+        "https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40",
+        "https://github.com/google/guava/issues/4011",
+        "https://security.netapp.com/advisory/ntap-20220210-0003/",
+        "https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3@%3Ctorque-dev.db.apache.org%3E",
+        "https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+        "https://www.oracle.com/security-alerts/cpuApr2021.html",
+        "https://www.oracle.com/security-alerts/cpuapr2022.html",
+        "https://www.oracle.com/security-alerts/cpujan2022.html",
+        "https://www.oracle.com/security-alerts/cpuoct2021.html",
+        "https://lists.apache.org/thread.html/rd01f5ff0164c468ec7abc96ff7646cea3cce6378da2e4aa29c6bcb95@%3Cgithub.arrow.apache.org%3E",
+        "https://lists.apache.org/thread.html/r4776f62dfae4a0006658542f43034a7fc199350e35a66d4e18164ee6@%3Ccommits.cxf.apache.org%3E",
+        "https://lists.apache.org/thread.html/rb8c0f1b7589864396690fe42a91a71dea9412e86eec66dc85bbacaaf@%3Ccommits.cxf.apache.org%3E",
+        "https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a@%3Ctorque-dev.db.apache.org%3E",
+        "https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604@%3Ctorque-dev.db.apache.org%3E",
+        "https://lists.apache.org/thread.html/r6874dfe26eefc41b7c9a5e4a0487846fc4accf8c78ff948b24a1104a@%3Cdev.drill.apache.org%3E",
+        "https://lists.apache.org/thread.html/r07ed3e4417ad043a27bee7bb33322e9bfc7d7e6d1719b8e3dfd95c14@%3Cdev.drill.apache.org%3E",
+        "https://lists.apache.org/thread.html/r2fe45d96eea8434b91592ca08109118f6308d60f6d0e21d52438cfb4@%3Cdev.drill.apache.org%3E",
+        "https://lists.apache.org/thread.html/r161b87f8037bbaff400194a63cd2016c9a69f5949f06dcc79beeab54@%3Cdev.drill.apache.org%3E",
+        "https://lists.apache.org/thread.html/rf9f0fa84b8ae1a285f0210bafec6de2a9eba083007d04640b82aa625@%3Cissues.geode.apache.org%3E",
+        "https://lists.apache.org/thread.html/r3dd8881de891598d622227e9840dd7c2ef1d08abbb49e9690c7ae1bc@%3Cissues.geode.apache.org%3E",
+        "https://lists.apache.org/thread.html/r5b3d93dfdfb7708e796e8762ab40edbde8ff8add48aba53e5ea26f44@%3Cissues.geode.apache.org%3E",
+        "https://lists.apache.org/thread.html/reebbd63c25bc1a946caa419cec2be78079f8449d1af48e52d47c9e85@%3Cissues.geode.apache.org%3E",
+        "https://lists.apache.org/thread.html/rc607bc52f3507b8b9c28c6a747c3122f51ac24afe80af2a670785b97@%3Cissues.geode.apache.org%3E",
+        "https://lists.apache.org/thread.html/r007add131977f4f576c232b25e024249a3d16f66aad14a4b52819d21@%3Ccommon-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/r58a8775205ab1839dba43054b09a9ab3b25b423a4170b2413c4067ac@%3Ccommon-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/rf00b688ffa620c990597f829ff85fdbba8bf73ee7bfb34783e1f0d4e@%3Cyarn-dev.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/r49549a8322f62cd3acfa4490d25bfba0be04f3f9ff4d14fe36199d27@%3Cyarn-dev.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/r5d61b98ceb7bba939a651de5900dbd67be3817db6bfcc41c6e04e199@%3Cyarn-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/r294be9d31c0312d2c0837087204b5d4bf49d0552890e6eec716fa6a6@%3Cyarn-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/re120f6b3d2f8222121080342c5801fdafca2f5188ceeb3b49c8a1d27@%3Cyarn-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/r7b0e81d8367264d6cad98766a469d64d11248eb654417809bfdacf09@%3Cyarn-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/ra7ab308481ee729f998691e8e3e02e93b1dedfc98f6b1cd3d86923b3@%3Cyarn-issues.hadoop.apache.org%3E",
+        "https://lists.apache.org/thread.html/rcafc3a637d82bdc9a24036b2ddcad1e519dd0e6f848fcc3d606fd78f@%3Cdev.hive.apache.org%3E",
+        "https://lists.apache.org/thread.html/rb2364f4cf4d274eab5a7ecfaf64bf575cedf8b0173551997c749d322@%3Cgitbox.hive.apache.org%3E",
+        "https://lists.apache.org/thread.html/r79e47ed555bdb1180e528420a7a2bb898541367a29a3bc6bbf0baf2c@%3Cissues.hive.apache.org%3E",
+        "https://lists.apache.org/thread.html/rd2704306ec729ccac726e50339b8a8f079515cc29ccb77713b16e7c5@%3Cissues.hive.apache.org%3E",
+        "https://lists.apache.org/thread.html/r841c5e14e1b55281523ebcde661ece00b38a0569e00ef5e12bd5f6ba@%3Cissues.maven.apache.org%3E",
+        "https://lists.apache.org/thread.html/rfc27e2727a20a574f39273e0432aa97486a332f9b3068f6ac1346594@%3Cdev.myfaces.apache.org%3E",
+        "https://lists.apache.org/thread.html/rd7e12d56d49d73e2b8549694974b07561b79b05455f7f781954231bf@%3Cdev.pig.apache.org%3E",
+        "https://lists.apache.org/thread.html/r3c3b33ee5bef0c67391d27a97cbfd89d44f328cf072b601b58d4e748@%3Ccommits.pulsar.apache.org%3E",
+        "https://lists.apache.org/thread.html/r215b3d50f56faeb2f9383505f3e62faa9f549bb23e8a9848b78a968e@%3Ccommits.ws.apache.org%3E",
+        "https://lists.apache.org/thread.html/r68d86f4b06c808204f62bcb254fcb5b0432528ee8d37a07ef4bc8222@%3Ccommits.ws.apache.org%3E",
+        "https://www.oracle.com//security-alerts/cpujul2021.html"
+      ],
+      "type": "security",
+      "watch_name": "all-watch",
+      "ignore_url": "https://acme.jfrog.io/xray/ir/c970becce",
+      "ignore_url_id": "7",
+      "is_high_profile": true,
+      "policies": [
+        {
+          "policy": "all-violations",
+          "rule": "all-violations",
+          "is_blocking": false,
+          "ignore_rule_id": ""
+        }
+      ],
+      "updated": "2022-12-18T11:34:52Z",
+      "extended_information": {
+        "short_description": "Improper temporary directory management in Guava can lead to data leakage",
+        "full_description": "[Guava](https://github.com/google/guava) is a set of core Java libraries from Google that includes new collection types (such as multimap and multiset), immutable collections, a graph library, and utilities for concurrency, I/O, hashing, caching, primitives, strings, and more. It is widely used on most Java projects within Google, and widely used by many other companies as well.\r\n\r\nThe `com.google.common.io.Files.createTempDir()` function creates a temporary directory according to the `java.io.tmpdir` system property, which points to the default temporary directory path. Thus, an attacker having access to the local filesystem, and specifically to the `java.io.tmpdir` directory can read all contents created under the directory returned from `com.google.common.io.Files.createTempDir()`. On Linux, by default, `java.io.tmpdir` points to `/tmp` which is world-readable.",
+        "jfrog_research_severity": "Low",
+        "jfrog_research_severity_reasons": [
+          {
+            "name": "Exploitation of the issue is only possible when the vulnerable component is used in a specific manner. The attacker has to perform per-target research to determine the vulnerable attack vector.",
+            "description": "Only applications that store sensitive files in the directory returned from a `com.google.common.io.Files.createTempDir()` API call, are affected by this vulnerability",
+            "is_positive": true
+          },
+          {
+            "name": "The issue can only be exploited by an attacker that can execute code on the vulnerable machine (excluding exceedingly rare circumstances)",
+            "description": "The attacker must have access to the filesystem and specifically to directories under `java.io.tmpdir`",
+            "is_positive": true
+          },
+          {
+            "name": "The issue is trivial to exploit and does not require a published writeup or PoC",
+            "description": "A local attacker can simply read files created under `java.io.tmpdir`",
+            "is_positive": false
+          }
+        ],
+        "remediation": "##### Development upgrade\n\n- Upgrade the component to any of the suggested fixed versions.\n\n##### Deployment mitigations\n\nSet the `java.io.tmpdir` property to a secure folder.\r\nAdd this option when running Java: ```java -Djava.io.tmpdir=/path/to/secure/tmpdir```"
+      }
+    }
+  ],
+  "scan_id": "04c02c5d-3e08-487f-443b-29cd2a5780c2",
+  "status": "completed",
+  "top_vuln_severity": "Critical",
+  "progress_percentage": 100
+}


### PR DESCRIPTION
Add fields in the `scan/graph` response required for the new UI in JFrog IDEA plugin:
* Add "extended_information"
* Add "updated" in violation
* Add "watch_name" in violation
* Add "edited" in vulnerability